### PR TITLE
Add ble transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use:
     $ npm install firmata-builder
     ```
 
-4. Navigate to the `examples` directory and run either of the following command:
+4. Navigate to the `examples` directory and run one of the following command:
 
     ```bash
     $ node demo.js
@@ -36,6 +36,10 @@ To use:
 
     ```bash
     $ node demo-ethernet.js
+    ```
+
+    ```bash
+    $ node demo-ble.js
     ```
 
     The first command above will generate a file named *ConfiguredFirmata.ino* and the second will generate a file named *ConfiguredFirmataWiFi.ino* in the same directory, etc. These examples also demonstrate the format of the object to be passed into the `build` method.

--- a/examples/demo-ble.js
+++ b/examples/demo-ble.js
@@ -1,0 +1,43 @@
+var fs = require("fs");
+
+var builder = require("../lib/builder.js").builder;
+
+/**
+ * builder.build expects an object with this structure
+ *
+ * controllers:
+ * "ARDUINO_101", "BLE_NANO"
+ * 
+ * BLE Nano support requires patching the RedBearLab nRF51822-Arduino
+ * core library. See steps 1 - 3 in this gist for instructions:
+ * https://gist.github.com/soundanalogous/d39bb3eb36333a0906df
+ *
+ */
+var simulatedUserInput = {
+  filename: "ConfiguredFirmataBLE",
+  connectionType: {
+    ble: {
+      controller: "ARDUINO_101",
+      minInterval: 6, // 7.5ms / 1.25
+      maxInterval: 24, // 30ms / 1.25
+      localName: "FIRMATA"
+    }
+  },
+  selectedFeatures: [
+    "DigitalInputFirmata",
+    "DigitalOutputFirmata",
+    "AnalogInputFirmata",
+    "AnalogOutputFirmata",
+    "ServoFirmata",
+    "I2CFirmata",
+    //"OneWireFirmata",
+    //"StepperFirmata",
+    //"SerialFirmata",
+    //"FirmataScheduler"
+  ]
+};
+
+var outputText = builder.build(simulatedUserInput);
+
+// write the Arduino skech (.ino) file
+fs.writeFileSync(simulatedUserInput.filename + ".ino", outputText);

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2015-2016 Jeff Hoefs under the terms of the MIT license found at
+ * Copyright 2015-2017 Jeff Hoefs under the terms of the MIT license found at
  * https://github.com/firmata/firmata-builder/blob/master/LICENSE-MIT
  */
 

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -7,6 +7,7 @@ var _ = require("lodash");
 var utils = require("./utils.js");
 var WiFiTransport = require("./transports/wifi.js");
 var EthernetTransport = require("./transports/ethernet.js");
+var BLETransport = require("./transports/ble.js");
 var SerialTransport = require("./transports/serial.js");
 var coreFeatures = require("./coreFeatures.js");
 var contributedFeatures = require("./contributedFeatures");
@@ -67,7 +68,8 @@ var builder = {
 
   controllers: {
     ethernet: EthernetTransport.controllers,
-    wifi: WiFiTransport.controllers
+    wifi: WiFiTransport.controllers,
+    ble: BLETransport.controllers,
   },
 
   /**
@@ -131,6 +133,10 @@ var builder = {
     } else if (config.ethernet) {
       transport = new EthernetTransport({
         configuration: config.ethernet
+      });
+    } else if (config.ble) {
+      transport = new BLETransport({
+        configuration: config.ble
       });
     } else if (config.serial) {
       transport = new SerialTransport({

--- a/lib/transports/ble.js
+++ b/lib/transports/ble.js
@@ -1,0 +1,158 @@
+var Controllers = {
+  ARDUINO_101: {
+    name: "Arduino 101",
+    driver: "CurieBLE"
+  },
+  BLE_NANO: {
+    name: "RedBearLab BLE Nano",
+    driver: "BLEPeripheral"
+  }
+};
+
+/**
+ * BLE transport.
+ * @constructor
+ * @param {Object} opts
+ */
+function BLETransport(opts) {
+  if (!(this instanceof BLETransport)) {
+    return new BLETransport(opts);
+  }
+
+  this.configuration = opts.configuration;
+  this.controller = Controllers[this.configuration.controller];
+  if (!this.controller) {
+    throw new Error("No valid BLE controller defined");
+  }
+}
+
+/**
+ * Creates the Ethernet configuration per the specified Etherent options.
+ * Added to top of sketch file.
+ */
+BLETransport.prototype.createConfigBlock = function() {
+  var config = "";
+  var configuration = this.configuration;
+
+  var MIN_INTERVAL = 6; // 7.5ms / 1.25 = 6
+  var DEFAULT_MAX_INTERVAL = 24; // 30ms / 1.25 = 24
+  var INTERVAL_INCREMENT = 1.25;
+  var minInterval = configuration.minInterval;
+  var maxInterval = configuration.maxInterval;
+
+  config += "// Uncomment to enable debugging over Serial (9600 baud).\n";
+  config += "//#define SERIAL_DEBUG\n";
+  config += "#include \"utility/firmataDebug.h\"\n\n";
+
+  switch (this.controller) {
+  case Controllers.ARDUINO_101:
+    config += "#include <CurieBLE.h>\n";
+    break;
+  case Controllers.BLE_NANO:
+    config += "// BLE Nano support requires patching the RedBearLab nRF51822-Arduino\n";
+    config += "// core library. See steps 1 - 3 in this gist for instructions:\n";
+    config += "// https://gist.github.com/soundanalogous/d39bb3eb36333a0906df\n";
+    config += "#include <BLEPeripheral.h>\n";
+    break;
+  }
+
+  config += "#include \"utility/BLEStream.h\"\n\n";
+
+  if (!minInterval || minInterval < MIN_INTERVAL) {
+    minInterval = MIN_INTERVAL;
+  }
+  minInterval = Math.floor(minInterval);
+  config += "// Specify min and max as time in ms / 1.25. The result must be an integer.\n"
+  config += "// For example 7.5ms = 7.5 / 1.25 = 6.\n";
+  config += "// Min interval cannot be < 6 (7.5ms / 1.25)\n";
+  config += "#define FIRMATA_BLE_MIN_INTERVAL " + minInterval + " // interval = time in ms / 1.25\n";
+
+  if (!maxInterval || maxInterval < minInterval) {
+    maxInterval = DEFAULT_MAX_INTERVAL;
+  }
+  maxInterval = Math.floor(maxInterval);
+  config += "#define FIRMATA_BLE_MAX_INTERVAL " + maxInterval + " // interval = time in ms / 1.25\n\n";
+
+  if (!configuration.localName) {
+    configuration.localName = "FIRMATA";
+  }
+
+  config += "// Change this to a unique name per board if running StandardFirmataBLE\n";
+  config += "// on multiple boards within the same physical space.\n";
+  config += "#define FIRMATA_BLE_LOCAL_NAME \"" + configuration.localName + "\"\n\n";
+
+  config += "BLEStream stream;\n\n";
+
+  return config;
+};
+
+/**
+ * Transport code at the beginning of the Arduino loop() function.
+ */
+BLETransport.prototype.createLoopBeginBlock = function () {
+  var text = "";
+  text += "  // stream.poll() will send the TX buffer at the specified flush interval or when\n";
+  text += "  // the buffer is full. It will return false if no BLE connection is established.\n";
+  text += "  if (!stream.poll()) return;\n\n";
+  return text;
+};
+
+/**
+ * Transport code at the end of the Arduino loop() function.
+ */
+BLETransport.prototype.createLoopEndBlock = function () {
+  return "";
+};
+
+/**
+ * Report when the host connection state changes
+ */
+BLETransport.prototype.createHostConnectionCallbackFn = function () {
+  return "";
+};
+
+/**
+ * Create a debug function to report the transport connection status.
+ */
+BLETransport.prototype.createDebugStatusFn = function () {
+  return "";
+};
+
+/**
+ * @return {boolean} true if configuration specifies controller pins to be ignored
+ */
+BLETransport.prototype.hasIgnorePins = function () {
+  return false;
+};
+
+/**
+ * Ignore pins used by the transport controller so that Firmata will not attempt to modify them.
+ */
+BLETransport.prototype.createIgnorePinsFn = function () {
+  return "";
+};
+
+BLETransport.prototype.createInitTransportFn = function () {
+  var fn = "";
+  fn += "void initTransport()\n";
+  fn += "{\n";
+
+  fn += "  // IMPORTANT: if SERIAL_DEBUG is enabled, program execution will stop\n";
+  fn += "  // at DEBUG_BEGIN until a Serial connection is established.\n";
+  fn += "  DEBUG_BEGIN(9600);\n\n";
+
+  fn += "  stream.setLocalName(FIRMATA_BLE_LOCAL_NAME);\n";
+  // set the BLE connection interval - this is the fastest interval you can read inputs
+  fn += "  stream.setConnectionInterval(FIRMATA_BLE_MIN_INTERVAL, FIRMATA_BLE_MAX_INTERVAL);\n";
+  fn += "  // Set how often the BLE TX buffer is flushed (if not full).\n";
+  fn += "  stream.setFlushInterval(FIRMATA_BLE_MAX_INTERVAL);\n\n";
+
+  fn += "  stream.begin();\n";
+  fn += "  Firmata.begin(stream);\n";
+  fn += "}\n\n";
+  return fn;
+};
+
+BLETransport.controllers = Controllers;
+
+module.exports = BLETransport;

--- a/lib/transports/wifi.js
+++ b/lib/transports/wifi.js
@@ -22,7 +22,7 @@ var Controllers = {
 /**
  * Wi-Fi transport. Currently configurable as server only on Arduino.
  * @constructor
- * @param {Objedt} opts
+ * @param {Object} opts
  */
 function WiFiTransport(opts) {
   if (!(this instanceof WiFiTransport)) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firmata-builder",
   "description": "Generates an Arduio sketch (.ino) file based on a selection of Firmata features.",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "homepage": "https://github.com/firmata/firmata-builder",
   "author": {
     "name": "Jeff Hoefs <soundanalogous@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "main": "lib/builder.js",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.12.0"
   },
   "dependencies": {
     "lodash": "^3.9.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firmata-builder",
   "description": "Generates an Arduio sketch (.ino) file based on a selection of Firmata features.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "homepage": "https://github.com/firmata/firmata-builder",
   "author": {
     "name": "Jeff Hoefs <soundanalogous@gmail.com>",

--- a/test/ble.test.js
+++ b/test/ble.test.js
@@ -1,0 +1,119 @@
+var _ = require("lodash");
+var expect = require("chai").expect;
+var BLETransport = require("../lib/transports/ble.js");
+
+describe("ble.js", function () {
+
+  var features = [
+    "DigitalInputFirmata",
+    "DigitalOutputFirmata",
+    "AnalogInputFirmata",
+    "AnalogOutputFirmata",
+    "ServoFirmata",
+    "I2CFirmata"
+  ];
+
+  var fakeDataArduino101 = {
+    filename: "TestFirmata",
+    connectionType: {
+      ble: {
+        controller: "ARDUINO_101",
+        minInterval: 6, // 7.5ms / 1.25
+        maxInterval: 24, // 30 ms / 1.25
+        localName: "FIRMATA"
+      }
+    },
+    selectedFeatures: features
+  };
+
+  var fakeDataBleNano = {
+    filename: "TestFirmata",
+    connectionType: {
+      ble: {
+        controller: "BLE_NANO",
+        minInterval: 6, // 7.5ms / 1.25
+        maxInterval: 24, // 30 ms / 1.25
+        localName: "FIRMATA"
+      }
+    },
+    selectedFeatures: features
+  };
+
+  describe("constructor", function () {
+    
+    it("should throw an error if no BLE controller is specified", function () {
+      var data = _.clone(fakeDataArduino101, true);
+      data.connectionType.ble.controller = "";
+      var fn = function () {
+        new WiFiTransport({configuration: data.connectionType.ble});
+      };
+      expect(fn).to.throw(Error);
+    });
+
+    it("should throw an error if an invalid BLE controller is specified", function () {
+      var data = _.clone(fakeDataArduino101, true);
+      data.connectionType.ble.controller = "INVALID_CONTROLLER";
+      var fn = function () {
+        new WiFiTransport({configuration: data.connectionType.ble});
+      };
+      expect(fn).to.throw(Error);
+    });
+
+  });
+
+  describe("createConfigBlock", function () {
+    var data;
+    var transport;
+
+    beforeEach(function () {
+      data = _.clone(fakeDataArduino101, true);
+      transport = new BLETransport({configuration: data.connectionType.ble});
+    });
+
+    it("should include the proper files for an Arduino 101", function () {
+      var text = transport.createConfigBlock();
+      expect(text).to.have.string("CurieBLE.h");
+      expect(text).to.have.string("BLEStream.h");
+    });
+
+    it("should include the proper files for a BLE Nano", function () {
+      transport = new BLETransport({configuration: fakeDataBleNano.connectionType.ble});
+      var text = transport.createConfigBlock();
+      expect(text).to.have.string("BLEPeripheral.h");
+      expect(text).to.have.string("BLEStream.h");
+    });
+
+    it("should limit the min interval to 6", function () {
+      transport.configuration.minInterval = 1;
+      var text = transport.createConfigBlock();
+      expect(text).to.have.string("FIRMATA_BLE_MIN_INTERVAL 6");
+    });
+
+    it("should ensure min and max interval are integers", function () {
+      transport.configuration.minInterval = 8.75;
+      transport.configuration.maxInterval = 25.3;
+      var text = transport.createConfigBlock();
+      expect(text).to.have.string("FIRMATA_BLE_MIN_INTERVAL 8");
+      expect(text).to.have.string("FIRMATA_BLE_MAX_INTERVAL 25");
+    });
+
+    it("should set 'FIRMATA' as the default localName value", function () {
+      transport.configuration.localName = "";
+      var text = transport.createConfigBlock();
+      expect(text).to.have.string("FIRMATA_BLE_LOCAL_NAME \"FIRMATA\"");
+    });
+
+    it("should all the user to specify a localName", function () {
+      transport.configuration.localName = "MY_LOCAL_NAME";
+      var text = transport.createConfigBlock();
+      expect(text).to.have.string("FIRMATA_BLE_LOCAL_NAME \"MY_LOCAL_NAME\"");
+    });
+
+    it("should create a BLEStream instance", function () {
+      var text = transport.createConfigBlock();
+      expect(text).to.have.string("BLEStream stream");
+    });
+
+  });
+
+});

--- a/test/builder.test.js
+++ b/test/builder.test.js
@@ -6,6 +6,7 @@ var builder = require("../lib/builder.js").builder;
 var SerialTransport = require("../lib/transports/serial.js");
 var EthernetTransport = require("../lib/transports/ethernet.js");
 var WiFiTransport = require("../lib/transports/wifi.js");
+var BLETransport = require("../lib/transports/ble.js");
 
 describe("builder.js", function () {
 
@@ -56,6 +57,19 @@ describe("builder.js", function () {
             passphrase: "your_wpa_passphrase"
           }
         }
+      }
+    },
+    selectedFeatures: featureList
+  };
+
+  var fakeDataBLE = {
+    filename: "TestFirmata",
+    connectionType: {
+      ble: {
+        controller: "ARDUINO_101",
+        minInterval: 6, // 7.5ms / 1.25
+        maxInterval: 24, // 30 ms / 1.25
+        localName: "FIRMATA"
       }
     },
     selectedFeatures: featureList
@@ -129,6 +143,11 @@ describe("builder.js", function () {
     it("should create a Wi-Fi transport", function () {
       builder.build(fakeDataWiFi);
       expect(builder.transport).to.be.instanceof(WiFiTransport);
+    });
+
+    it("should create a BLE transport", function () {
+      builder.build(fakeDataBLE);
+      expect(builder.transport).to.be.instanceof(BLETransport);
     });
 
   });
@@ -428,6 +447,11 @@ describe("builder.js", function () {
     it("should include call to ignorePins() if Ethernet and pins should be ignored", function () {
       var text = builder.build(fakeDataEthernet);
       expect(text).to.have.string("ignorePins()");
+    });
+
+    it("should include call to stream.poll() if BLE transport", function () {
+      var text = builder.build(fakeDataBLE);
+      expect(text).to.have.string("if (!stream.poll()) return");
     });
 
   });


### PR DESCRIPTION
Adds option for BLE transport. Limited to Arduino 101 and BLE Nano. BLE Nano only supported via a patch to the RedBearLab nRF51822-Arduino core library.

Closes issue #16. 