### PR TITLE
Change setup() builder to avoid spurious analog reports from device.

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -313,7 +313,7 @@ var builder = {
 
     fn += "  initTransport();\n\n";
 
-    fn += "  systemResetCallback();\n";
+    fn += "  Firmata.parse(SYSTEM_RESET);\n";
 
     fn += "}\n\n";
     return fn;

--- a/test/builder.test.js
+++ b/test/builder.test.js
@@ -370,8 +370,8 @@ describe("builder.js", function () {
       expect(text).to.have.string("initTransport();");
     });
 
-    it("should include call to systemResetCallback()", function () {
-      expect(text).to.have.string("systemResetCallback();");
+    it("should include call to Firmata.parse(SYSTEM_RESET)", function () {
+      expect(text).to.have.string("Firmata.parse(SYSTEM_RESET);");
     });
   });
 


### PR DESCRIPTION
As discussed in firmata/ConfigurableFirmata#81, this prevents spurious analog pin reporting behavior at the end of setup. I was able to run two basic tests of the sketch created by `examples/demo.js` on an Arduino Uno:

- I ran the blink script discussed in the initial report in firmata/ConfigurableFirmata#81 and confirmed successful execution of the script.
- I ran a blink program implemented in Snap4Arduino (running on a ChromeOS environment) and confirmed successful connection of the Arduino board and execution of the program.

I wasn't sure how to best rename the unit test for this change - please let me know if a less literal test name would be more appropriate.